### PR TITLE
Fix the post_batch_usage_event method to correctly format the API request

### DIFF
--- a/sdk/src/azuremarketplace/microsoft/marketplace/meter/operations/_metering_operations_operations.py
+++ b/sdk/src/azuremarketplace/microsoft/marketplace/meter/operations/_metering_operations_operations.py
@@ -171,7 +171,7 @@ class MeteringOperationsOperations(object):
         header_parameters['Accept'] = self._serialize.header("accept", accept, 'str')
 
         body_content_kwargs = {}  # type: Dict[str, Any]
-        body_content = self._serialize.body(body, '[UsageEvent]')
+        body_content = {'request': self._serialize.body(body, '[UsageEvent]')}
         body_content_kwargs['content'] = body_content
         request = self._client.post(url, query_parameters, header_parameters, **body_content_kwargs)
         pipeline_response = self._client._pipeline.run(request, stream=False, **kwargs)


### PR DESCRIPTION
See the documentation link below for more information about the formatting; in this case it was missing `request` as main body key

https://learn.microsoft.com/en-us/partner-center/marketplace/marketplace-metering-service-apis#metered-billing-batch-usage-event